### PR TITLE
[JOSS review] Fix section links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
 [![Tests](https://img.shields.io/badge/tests-passing-brightgreen.svg)]()
 
-[Features](#-features) •
-[Installation](#-installation) •
-[Quick Start](#-quick-start) •
-[Documentation](#-documentation) •
-[Examples](#-examples) •
-[Roadmap](#-roadmap)
+[Features](#features) •
+[Installation](#installation) •
+[Quick Start](#quick-start) •
+[Documentation](#documentation) •
+[Examples](#examples) •
+[Roadmap](#roadmap)
 
 </div>
 


### PR DESCRIPTION
Towards https://github.com/openjournals/joss-reviews/issues/9729

## Summary

The links to sections in the README don't work because they include unnecessary hyphens.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Chore/maintenance

## Checklist

- [ ] I opened/linked an issue discussing this change (for significant changes)
- [ ] I added/updated tests and they pass locally (`pytest -q`)
- [ ] I ran linters (`flake8`) and optional type-checks (`mypy`)
- [ ] I updated documentation/README examples if behavior changed
- [ ] CI is green on this PR
