### PR TITLE
Fix path to `CONTRIBUTING.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ print(f"Final quality: {improved_editor.mesh_min_angle():.2f}°")
 
 - **[API Reference](docs/API_REFERENCE.md)** - Complete API documentation
 - **[Examples](examples/)** - Practical usage examples
-- **[Contributing](CONTRIBUTING.md)** - How to contribute
+- **[Contributing](docs/CONTRIBUTING.md)** - How to contribute
 - **[Publication Strategy](docs/PUBLICATION_STRATEGY.md)** - Development roadmap
 
 ---


### PR DESCRIPTION
Closes #3
Towards https://github.com/openjournals/joss-reviews/issues/9729

## Summary

I found the file. This PR fixes the path in the README.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Docs update
- [x] Chore/maintenance

## Checklist

- [ ] I opened/linked an issue discussing this change (for significant changes)
- [ ] I added/updated tests and they pass locally (`pytest -q`)
- [ ] I ran linters (`flake8`) and optional type-checks (`mypy`)
- [ ] I updated documentation/README examples if behavior changed
- [ ] CI is green on this PR
